### PR TITLE
테스트 오류 1차 수정

### DIFF
--- a/src/main/java/com/jcticket/user/controller/SignUpController.java
+++ b/src/main/java/com/jcticket/user/controller/SignUpController.java
@@ -58,8 +58,14 @@ public class SignUpController {
 //    이메일 인증번호 발송 시작
     @ResponseBody
     @GetMapping("/emailChk")
-    public String emailChk(@RequestParam("totalEmail") String totalEmail) throws MessagingException {
+    public String emailChk(@RequestParam("totalEmail") String totalEmail) throws Exception {
         System.out.println("totalEmail = " + totalEmail);
+        String num = "";
+
+        if(userService.chkEmailDupl(totalEmail) == 1){
+            num = "duplicate";
+            return num;
+        }
 
         //난수6자리 인증번호
         int authNum = (int)(Math.random()*(999999-100000+1)+100000);
@@ -69,7 +75,7 @@ public class SignUpController {
         String title = "회원가입시 필요한 인증번호 입니다."; //메일 제목
         String content = "[인증번호] "+authNum+" 입니다. <br/> 인증번호 확인란에 기입해주세요."; // 메일 내용
 
-        String num = "";
+
         try {
             MimeMessage mail = mailSender.createMimeMessage();
             MimeMessageHelper mailHelper = new MimeMessageHelper(mail, true, "utf-8");
@@ -168,10 +174,10 @@ public class SignUpController {
             Map<String, String> validatorRslt = cvh.validateHandling(bindingResult);
 
             for (String key: validatorRslt.keySet()) {
-                rattr.addFlashAttribute(key, validatorRslt.get(key));
+                m.addAttribute(key, validatorRslt.get(key));
             }
 
-            return "redirect:/signup";
+            return "signup/signup";
         }
 
         try{

--- a/src/main/java/com/jcticket/user/dao/UserDao.java
+++ b/src/main/java/com/jcticket/user/dao/UserDao.java
@@ -25,6 +25,9 @@ public interface UserDao {
     int selectIdDupl(String user_id) throws Exception;//
     //닉네임 중복 확인
     int selectNickNameDupl(String user_nickname) throws Exception;//
+    //이메일 중복 확인
+    int selectEmailDupl(String user_email) throws Exception;//
+
     //회원가입
     int insert(UserDto userDto) throws Exception; //
     List<Map<String, Object>> selectImg() throws Exception;

--- a/src/main/java/com/jcticket/user/dao/UserDaoImpl.java
+++ b/src/main/java/com/jcticket/user/dao/UserDaoImpl.java
@@ -47,6 +47,11 @@ public class UserDaoImpl implements UserDao {
         return session.selectOne(namespace+"chk_NickName_Dupl",user_nickname);
     }
 
+    @Override
+    public int selectEmailDupl(String user_email) throws Exception {
+        return session.selectOne(namespace+"chk_Email_Dupl",user_email);
+    }
+
     //회원가입
     @Override
     public int insert(UserDto userDto) throws Exception {

--- a/src/main/java/com/jcticket/user/dto/UserDto.java
+++ b/src/main/java/com/jcticket/user/dto/UserDto.java
@@ -27,13 +27,16 @@ import java.sql.Timestamp;
 @EqualsAndHashCode
 public class UserDto {
     @NotBlank(message = "아이디는 필수 입력 값입니다.")
+    @Pattern(regexp = "^[a-z0-9]{4,}$", message = "특수문자 또는 공백을 사용할 수 없으며, 4글자 이상 입력해주세요.")
     private String user_id;
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String user_password;
     @NotBlank(message = "이름은 필수 입력 값입니다.")
+    @Pattern(regexp = "^[가-힣]+$", message = "한글만 입력 가능합니다.")
     private String user_name;
     @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    @Pattern(regexp = "^[a-zA-z0-9가-힣]+$", message = "영문 대문자, 소문자, 한글단어, 숫자를 포함한 10자 이하만 입력가능합니다.")
     private String user_nickname;
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/com/jcticket/user/service/UserService.java
+++ b/src/main/java/com/jcticket/user/service/UserService.java
@@ -26,6 +26,8 @@ public interface UserService {
     int chkIdDupl(String user_id) throws Exception;
     //닉네임 중복확인
     int chkNickNameDupl(String user_nickname) throws Exception;
+    //이메일 중복 확인
+    int chkEmailDupl(String user_email) throws Exception;
     //회원가입
     int signup(UserDto userDto) throws Exception;
     //sns회원가입

--- a/src/main/java/com/jcticket/user/service/UserServiceImpl.java
+++ b/src/main/java/com/jcticket/user/service/UserServiceImpl.java
@@ -66,6 +66,11 @@ public class UserServiceImpl implements UserService {
         return userDao.selectNickNameDupl(user_nickname);
     }
 
+    @Override
+    public int chkEmailDupl(String user_email) throws Exception {
+        return userDao.selectEmailDupl(user_email);
+    }
+
     //로그인 검사. 입력한 아이디의 비밀번호 일치하는지
     @Override
     public boolean loginCheck(String user_id, String user_password) throws Exception {

--- a/src/main/resources/mybatis/mapper/user/userMapper.xml
+++ b/src/main/resources/mybatis/mapper/user/userMapper.xml
@@ -205,6 +205,13 @@
         where user_nickname = #{user_nickname}
     </select>
 
+    <select id="chk_Email_Dupl" parameterType="String" resultType="int">
+        select count(*)
+        from user
+        where user_email = #{user_email}
+    </select>
+
+
 
 
     <delete id="delete" parameterType="String">

--- a/src/main/webapp/WEB-INF/views/signup/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/signup/signup.jsp
@@ -100,7 +100,7 @@
                     영문 소문자,숫자만을 사용한 4글자 이상, 20글자 이하
                 </div>
                 <label>
-                    <input type="text" id="userIdInput" value="${userDto.user_id}" class="css_idPwdNickTelAddGenBir_input" name="user_id" placeholder="아이디" >
+                    <input type="text" id="userIdInput" value="${userDto.user_id}" class="css_idPwdNickTelAddGenBir_input" name="user_id" placeholder="아이디"  maxlength="20">
                 </label>
                 <div id="id_warnMsg">${valid_user_id}</div>
             </div>
@@ -136,10 +136,10 @@
             <div class="idPwdNickTelAddGenBir_Wrap">
                 <label class="css_idPwdNickTelAddGenBir_label">닉네임</label>
                 <div class="css_idPwdNickTelAddGenBir_div">
-                    사용할 닉네임을 입력해주세요.
+                    영문 대문자, 소문자, 한글단어, 숫자를 포함한 10자 이하
                 </div>
                 <label>
-                    <input type="text" id="userNicknameInput" value="${userDto.user_nickname}" class="css_idPwdNickTelAddGenBir_input" name="user_nickname" placeholder="닉네임" maxlength="30">
+                    <input type="text" id="userNicknameInput" value="${userDto.user_nickname}" class="css_idPwdNickTelAddGenBir_input" name="user_nickname" placeholder="닉네임" maxlength="10">
                 </label>
                 <div id="nickname_warnMsg">${valid_user_nickname}</div>
             </div>

--- a/src/main/webapp/resources/js/signup/signup.js
+++ b/src/main/webapp/resources/js/signup/signup.js
@@ -51,6 +51,8 @@ $('#emailBtn').on('click',function (){
         success:function(data){
             if(data==="error"){
                 alert("이메일 주소가 올바르지 않습니다. 유효한 이메일 주소를 입력해주세요.");
+            }else if(data==="duplicate"){
+                alert("이미 가입된 이메일입니다. 다른 이메일을 입력해주세요.");
             }else{
                 alert("인증번호 발송이 완료되었습니다.\n입력한 이메일에서 인증번호를 확인해주세요.");
             }
@@ -187,27 +189,51 @@ $('#userPwdChkInput').on('keyup',function (){
 //닉네임 중복 체크 시작
     $('#userNicknameInput').on('keyup',function (){
         const nicknameValue = $('#userNicknameInput').val();
-        $.ajax({
-            url:sessionStorage.getItem("contextpath") + '/signup/chk_nickname_dupl',
-            method: 'POST',
-            data:{user_nickname:nicknameValue},
-            success:function(data){
-                if(data){
-                    $('#nickname_warnMsg').css('display', 'block');
-                    $('#nickname_warnMsg').css('color', 'orangered');
-                    $('#nickname_warnMsg').html("이미 사용 중인 닉네임입니다.");
-                } else {
-                    $('#nickname_warnMsg').css('display', 'block');
-                    $('#nickname_warnMsg').css('color','rgb(0, 159, 206)');
-                    $('#nickname_warnMsg').html("사용 가능한 닉네임입니다.");
+        const regEx = /^[a-zA-z0-9가-힣]+$/ //특수문자 및 공백 포함 여부 확인
+
+
+        if(!(regEx.test(nicknameValue))){
+            $('#nickname_warnMsg').css('display', 'block');
+            $('#nickname_warnMsg').css('color','orangered')
+            $('#nickname_warnMsg').html("영문 대문자, 소문자, 한글단어, 숫자를 포함한 10자 이하만 입력가능합니다.");
+        }else if((regEx.test(nicknameValue))){
+            $.ajax({
+                url:sessionStorage.getItem("contextpath") + '/signup/chk_nickname_dupl',
+                method: 'POST',
+                data:{user_nickname:nicknameValue},
+                success:function(data){
+                    if(data){
+                        $('#nickname_warnMsg').css('display', 'block');
+                        $('#nickname_warnMsg').css('color', 'orangered');
+                        $('#nickname_warnMsg').html("이미 사용 중인 닉네임입니다.");
+                    } else {
+                        $('#nickname_warnMsg').css('display', 'block');
+                        $('#nickname_warnMsg').css('color','rgb(0, 159, 206)');
+                        $('#nickname_warnMsg').html("사용 가능한 닉네임입니다.");
+                    }
+                },
+                error:function(xhr, status, error) {
+                    console.error('AJAX Error:', error);
                 }
-            },
-            error:function(xhr, status, error) {
-            console.error('AJAX Error:', error);
+            })
         }
-        })
+
     })
 //닉네임 중복 체크 끝
+
+// 이름 유효성 검사 시작
+$('#userNameInput').on('keyup',function(){
+    const nameValue = $('#userNameInput').val()
+    const regEx = /^[a-z가-힣]+$/
+
+    if(!(regEx.test(nameValue))){
+        $('#name_warnMsg').css('display', 'block');
+        $('#name_warnMsg').css('color','orangered');
+        $('#name_warnMsg').html("한글만 입력 가능합니다.");
+    }
+
+})
+// 이름 유효성 검사 끝
 
 
 //전화번호 유효성 검사 시작


### PR DESCRIPTION
2024.03.16 테스트 1차 수정
1. 회원가입 폼 오류시 기존 데이터가 입력창에서 사라지는 에러
->기존의 코드는 redirect여서 페이지가 한번 새로고침됨. return signup/signup으로 수정 후 테스트하니 잘 들어오는거 확인

2. 중복이메일 회원가입되는 에러
이메일 인증하기 버튼 클릭시 중복이메일이 있으면  alert("이미 가입된 이메일입니다. 다른 이메일을 입력해주세요."); 띄움.

3. 회원가입시 아이디 필드에서 아이디를 계속 끊임없이 입력하면 유효성검사 뚫림 
-> maxlength = 20으로 해결

4. 회원가입시 닉네임 , 이름 필드에 유효성검사가 안됨 공백포함 아무문자 다 들어감
-> 숫자,영문,한글단어 정규식 추가
-> 영문 대문자, 소문자, 한글단어, 숫자를 포함한 10자 이하      라는 문구 추가
-> maxlength 30 에서 너무 긴것같아 10으로 변경


메인페이지 슬라이드 이미지 안보이는 현상(일시적인 서버 문제일 가능성 높음)
-> 해결 아직 못했습니다. 추후에 관찰하면서 해결하겠습니다.